### PR TITLE
Create pzbl.tokenlist.json

### DIFF
--- a/src/pzbl.tokenlist.json
+++ b/src/pzbl.tokenlist.json
@@ -1,0 +1,23 @@
+{
+  "name": "PZBL Token List",
+  "timestamp": "2025-06-09T00:00:00+00:00",
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "tokens": [
+    {
+      "chainId": 137,
+      "address": "0xd6a5fb585b14a882a8d60b21ff8ffeab6cc8f946",
+      "name": "Pizzaballa",
+      "symbol": "PZBL",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/todd72113/token-lists/main/src/PZBL_logo_512x512.png",
+      "website": "https://pzblcoin.com",
+      "description": "PZBL is a meme token on Polygon, blending humor and charity with real utility."
+    }
+  ],
+  "keywords": ["memecoin", "polygon", "charity"]
+}
+Add new token list with updated logo URI


### PR DESCRIPTION
This pull request updates the PZBL token list with the correct logoURI hosted on GitHub.  
- Chain: Polygon (137)  
- Token: Pizzaballa ($PZBL)  
- Website: https://pzblcoin.com  
- LogoURI: https://raw.githubusercontent.com/todd72113/token-lists/main/src/PZBL_logo_512x512.png  

Thank you for considering this update!
